### PR TITLE
fix(twitch): gestion des erreurs de rate limit de l’API

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -30,5 +30,9 @@ OBS_WEBSOCKET_MAX_RECONNECT_ATTEMPTS=10
 # =================================
 # STREAMING CONFIGURATION
 # =================================
-# Intervalle de mise à jour des streams en millisecondes
-STREAM_UPDATE_INTERVAL=30000
+# Intervalle de mise à jour des streams en millisecondes (recommandé: 180000 = 3 minutes pour éviter rate limit)
+STREAM_UPDATE_INTERVAL=180000
+# Nombre de vérifications échouées avant de marquer un stream comme offline (pour éviter les faux positifs)
+STREAM_OFFLINE_GRACE_PERIOD=2
+# Taille maximum des batches pour les requêtes API Twitch (max 100)
+TWITCH_API_BATCH_SIZE=20


### PR DESCRIPTION
Amélioration du **monitoring des streams Twitch** pour éviter les problèmes liés au **rate limit** de l’API Helix.
La configuration de l'api est désormais **personnalisable a partir du .env**.

---

### ✅ Changements principaux

* Ajout du **batching des requêtes** (par défaut 15–20 par lot) avec pause (500 ms)
* Gestion du code `429 Too Many Requests`

---

### 🧪 Tests manuels

* Vérification que les batchs respectent les limites API
* Streamers marqués offline uniquement après la fin du stream
* Frontend reflète correctement l’état des streams via `/api/streams`