### PR TITLE
Update .gitignore

### DIFF
--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -65,3 +65,6 @@ Thumbs.db
 # Temporary files
 tmp/
 temp/
+
+# JSON Local File
+streams.json


### PR DESCRIPTION
Mise à jour du fichier `.gitignore` pour exclure `streams.json` du suivi Git.

---

### ✅ Changements

* Ajout d’une règle dans `.gitignore` pour ignorer `streams.json` (fichier local/json de configuration).