### PR TITLE
feat(config): ajout de la configuration de l’hôte pour l’API et l'UI

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -4078,7 +4078,9 @@ function startServer(port = DEFAULT_PORT) {
     res.end('Not Found');
   });
 
-  srv.listen(port, () => {
+  const host = process.env.HOST || 'localhost';
+  
+  srv.listen(port, host, () => {
     const asciiLogo = [
       '\x1b[36m',
       "  ______________      ________ _   _ _______     _____ _                            _ _       _    ",
@@ -4090,7 +4092,7 @@ function startServer(port = DEFAULT_PORT) {
       '\x1b[0m'
     ].join('\n');
     logAlways(asciiLogo);
-    logAlways(`\x1b[32m[API]\x1b[0m listening on http://localhost:${port}`);
+    logAlways(`\x1b[32m[API]\x1b[0m listening on http://${host}:${port}`);
     
     updateStreamsZEventInfo().catch(e => {
       logError('[ZEvent] Failed to update stream info:', e.message);

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,1 +1,5 @@
 VITE_API_BASE_URL=http://localhost:3001
+
+# Configuration du serveur de développement
+VITE_PORT=80
+VITE_HOST=0.0.0.0

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -1,9 +1,20 @@
-import { defineConfig } from 'vite'
+import { defineConfig, loadEnv } from 'vite'
 import vue from '@vitejs/plugin-vue'
 
-export default defineConfig({
-  plugins: [vue()],
-  server: {
-    port: 5173
+export default defineConfig(({ mode }) => {
+  // Charger les variables d'environnement
+  const env = loadEnv(mode, process.cwd(), '')
+  
+  return {
+    plugins: [vue()],
+    server: {
+      host: env.VITE_HOST || '0.0.0.0',
+      port: parseInt(env.VITE_PORT) || 80,
+      allowedHosts: [
+        'streamlink.zevent',
+        'localhost',
+        '127.0.0.1'
+      ]
+    }
   }
 })


### PR DESCRIPTION
Ajout d’une configuration dédiée pour définir l’**hôte de l’API** et de l’**UI**.

---

### ✅ Changements

* Ajout de nouvelles variables dans la configuration (`.env`)
* Mise à jour du fichier `.env.example` avec les clés correspondantes