### PR TITLE
fix: affichage badge ZEvent

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -2929,7 +2929,7 @@ async function handleApi(req, res) {
             m3u8Url: stream.m3u8Url || stream.httpUrl,
             quality: stream.quality,
             isLive: twitchStatus.online,
-            isZEvent: isZEvent,
+            isZEventStreamer: isZEvent, // Utiliser le nom cohérent avec le frontend
             twitchTitle: twitchStatus.title,
             twitchViewers: twitchStatus.viewers,
             profileUrl: twitchStatus.profileUrl,
@@ -2964,7 +2964,7 @@ async function handleApi(req, res) {
             m3u8Url: stream.m3u8Url || stream.httpUrl,
             quality: stream.quality,
             isLive: false,
-            isZEvent: isZEvent,
+            isZEventStreamer: isZEvent, // Utiliser le nom cohérent avec le frontend
             twitchTitle: null,
             twitchViewers: null,
             profileUrl: null,

--- a/frontend/src/components/StreamerCard.vue
+++ b/frontend/src/components/StreamerCard.vue
@@ -58,7 +58,7 @@
           <h3 class="streamer-name">
             {{ stream.name }}
             <div class="zevent-badge-container">
-              <img v-if="true" 
+              <img v-if="isZeventStreamer" 
                    src="/badge_zevent.png" 
                    class="zevent-heart-badge" 
                    alt="ZEvent 2025" />
@@ -317,15 +317,13 @@ const zeventStreamer = computed(() => {
 // Vérifie si c'est un streamer ZEvent
 const isZeventStreamer = computed(() => {
   console.log('DEBUG - Stream data:', props.stream.name, props.stream)
-  // Utilise d'abord la propriété du stream (backend)
-  if (props.stream.isZEventStreamer !== undefined) {
-    console.log('Stream ZEvent status (backend):', props.stream.name, props.stream.isZEventStreamer)
-    return Boolean(props.stream.isZEventStreamer)
-  }
-  // Fallback sur la recherche dans la liste ZEvent
-  const fallback = Boolean(zeventStreamer.value)
-  console.log('Fallback ZEvent status:', props.stream.name, fallback)
-  return fallback
+  
+  // Utilise la propriété du stream (backend) - doit toujours être définie maintenant
+  const backendValue = props.stream.isZEventStreamer
+  console.log('Stream ZEvent status (backend):', props.stream.name, backendValue, typeof backendValue)
+  
+  // Retourner directement la valeur du backend (false ou true)
+  return Boolean(backendValue)
 })
 
 // État du flux


### PR DESCRIPTION
Correction d’un bug où le **badge ZEvent** s’affichait pour des streamers qui ne font pas partie de la liste officielle fournie par l’API ZEvent.

---

### ✅ Changements

* Vérification de la présence du streamer dans la liste ZEvent avant affichage du badge
* Suppression du badge pour les streamers ajoutés manuellement

---

### 🧪 Tests

* Ajout d’un streamer hors liste → badge absent (✅ attendu)
* Ajout d’un streamer officiel ZEvent → badge présent (✅ attendu)
