### PR TITLE
fix(obs): ordre des scènes importées

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -2090,8 +2090,8 @@ async function discoverExistingOBSScenes() {
     let streamId = 1;
     
     // Chercher toutes les scènes qui suivent le format Stream_<streamer>
-    // L'ordre est préservé car on parcourt sceneList.scenes dans l'ordre OBS
-    for (const scene of sceneList.scenes) {
+    // L'ordre est inversé car OBS retourne les scènes dans l'ordre inverse de celui désiré
+    for (const scene of sceneList.scenes.slice().reverse()) {
       const sceneName = scene.sceneName;
       
       // Vérifier si la scène suit le format Stream_<streamer>


### PR DESCRIPTION
Correction d’un bug où l’**ordre des scènes importées depuis OBS** n’était pas respecté lors du chargement automatique.

---

### ✅ Changements

* Maintien strict de l’ordre défini dans OBS lors de l’import automatique
* Mise à jour de la logique de synchronisation pour éviter les inversions

---

### 🧪 Tests

* Vérification avec plusieurs scènes OBS